### PR TITLE
addDeviceNameBasedDiscoveryPair for Windows

### DIFF
--- a/src/Launchpad-Pro-Mk3-for-Bitwig.control.ts
+++ b/src/Launchpad-Pro-Mk3-for-Bitwig.control.ts
@@ -57,8 +57,8 @@ host.addDeviceNameBasedDiscoveryPair(
 );
 // Windows:
 host.addDeviceNameBasedDiscoveryPair(
-  ["MIDIIN3 (LLProMK3 MIDI)", "LLProMK3 MIDI"],
-  ["MIDIIN3 (LLProMK3 MIDI)", "LLProMK3 MIDI"]
+  ["MIDIIN3 (LPProMK3 MIDI)", "LPProMK3 MIDI"],
+  ["MIDIIN3 (LPProMK3 MIDI)", "LPProMK3 MIDI"]
 );
 
 const Layers = {

--- a/src/Launchpad-Pro-Mk3-for-Bitwig.control.ts
+++ b/src/Launchpad-Pro-Mk3-for-Bitwig.control.ts
@@ -50,9 +50,15 @@ host.defineController(
 host.defineMidiPorts(2, 2);
 
 // TODO: Update these, I only "know" the Mac pair, but they don't even work.
+// macOS:
 host.addDeviceNameBasedDiscoveryPair(
   ["Launchpad Pro MK3 LPProMK3 DAW", "Launchpad Pro MK3 LPProMK3 MIDI"],
   ["Launchpad Pro MK3 LPProMK3 DAW", "Launchpad Pro MK3 LPProMK3 MIDI"]
+);
+// Windows:
+host.addDeviceNameBasedDiscoveryPair(
+  ["MIDIIN3 (LLProMK3 MIDI)", "LLProMK3 MIDI"],
+  ["MIDIIN3 (LLProMK3 MIDI)", "LLProMK3 MIDI"]
 );
 
 const Layers = {

--- a/src/Launchpad-Pro-Mk3-for-Bitwig.control.ts
+++ b/src/Launchpad-Pro-Mk3-for-Bitwig.control.ts
@@ -58,7 +58,7 @@ host.addDeviceNameBasedDiscoveryPair(
 // Windows:
 host.addDeviceNameBasedDiscoveryPair(
   ["MIDIIN3 (LPProMK3 MIDI)", "LPProMK3 MIDI"],
-  ["MIDIIN3 (LPProMK3 MIDI)", "LPProMK3 MIDI"]
+  ["MIDIOUT3 (LPProMK3 MIDI)", "LPProMK3 MIDI"]
 );
 
 const Layers = {


### PR DESCRIPTION
Those should be the right MIDI device names for Windows, but I also remember having troubles getting the autodetection to work.

I guess it doesn't hurt adding it. When reading the API docs this seems to be the right way to do it?

![image](https://user-images.githubusercontent.com/470980/150005886-d507ee29-483c-4799-a703-9bc7be7a6ee0.png)
