### PR TITLE
Remove unnecessary "any" type and add missing typing info

### DIFF
--- a/src/LaunchPad.ts
+++ b/src/LaunchPad.ts
@@ -67,7 +67,7 @@ class LaunchPad {
   public static numDrumPads = 64;
 
   // Some State.
-  public state: any = {
+  public state = {
     orientation: Orientation.Mix,
     quantizeGrid: "1/16",
     fixedLength: "play_recorded",
@@ -137,7 +137,7 @@ class LaunchPad {
     {
       let prefs = host.getPreferences();
       ext.prefs.orientation = prefs.getEnumSetting("Orientation", "Grid", PrefOrientation, PrefOrientation[0]);
-      ext.prefs.orientation.addValueObserver((v: any) => {
+      ext.prefs.orientation.addValueObserver((v) => {
         switch (v) {
           case "Mix Only":
             this.state.orientation = Orientation.Mix
@@ -157,12 +157,12 @@ class LaunchPad {
       ext.prefs.panOrientation = prefs.getEnumSetting("Pan Faders", "Grid", PrefPanFader, PrefPanFader[0]);
 
       ext.prefs.scenesIndication = prefs.getBooleanSetting("Scenes", "Indicators", false);
-      ext.prefs.scenesIndication.addValueObserver((v: any) => {
+      ext.prefs.scenesIndication.addValueObserver((v) => {
         ext.sceneBank.setIndication(v);
       });
 
       ext.prefs.slotsIndication = prefs.getBooleanSetting("Slots", "Indicators", false);
-      ext.prefs.slotsIndication.addValueObserver((v: any) => {
+      ext.prefs.slotsIndication.addValueObserver((v) => {
         for (let trackIdx = 0; trackIdx < LaunchPad.numTracks; trackIdx++) {
           ext.trackBank.getItemAt(trackIdx).clipLauncherSlotBank().setIndication(v);
         }

--- a/src/Launchpad-Pro-Mk3-for-Bitwig.control.ts
+++ b/src/Launchpad-Pro-Mk3-for-Bitwig.control.ts
@@ -73,7 +73,18 @@ const Layers = {
   StopClip: new StopClipLayer(),
 }
 
-// @ts-expect-error
+type SettableValue = com.bitwig.extension.controller.api.SettableBeatTimeValue
+  | com.bitwig.extension.controller.api.SettableBooleanValue
+  | com.bitwig.extension.controller.api.SettableColorValue
+  | com.bitwig.extension.controller.api.SettableDoubleValue
+  | com.bitwig.extension.controller.api.SettableEnumValue
+  | com.bitwig.extension.controller.api.SettableIntegerValue
+  | com.bitwig.extension.controller.api.SettableRangedValue
+  | com.bitwig.extension.controller.api.SettableStringArrayValue
+  | com.bitwig.extension.controller.api.SettableStringValue
+  ;
+
+// @ts-ignore
 const ext: {
   // Bitwig API
   app: API.Application;
@@ -90,7 +101,7 @@ const ext: {
   cursorTrackFirstDevice: API.PinnableCursorDevice;
   cursorRemote: API.CursorRemoteControlsPage;
   cursorDrumPadBank: API.DrumPadBank;
-  prefs: any;
+  prefs: Record<string, SettableValue>;
   // Our API
   grid: Grid;
   buttons: Buttons;

--- a/src/Layer.ts
+++ b/src/Layer.ts
@@ -206,7 +206,7 @@ class Layer {
 
   public static orientation: Orientation = Orientation.Mix;
 
-  private static canScroll: any = {
+  private static canScroll = {
     tracksUp: false,
     tracksDown: false,
     scenesUp: false,
@@ -312,11 +312,11 @@ class Layer {
     Layer.getCurrent().updateScrolling();
   }
 
-  public static getScroll(dir: string) {
+  public static getScroll(dir: ScrollDir) {
     return Layer.canScroll[dir];
   }
 
-  public static setScroll(dir: string, canScroll: boolean) {
+  public static setScroll(dir: ScrollDir, canScroll: boolean) {
     Layer.canScroll[dir] = canScroll;
     Layer.getCurrent().updateScrolling();
   }
@@ -349,3 +349,5 @@ class Layer {
   }
 
 }
+
+type ScrollDir = keyof typeof Layer["canScroll"];


### PR DESCRIPTION
Just some quick review on typing, this adds some more completion.

Just a question on the "global" object ext, why is not included in launchpad itself?  
Sorry I'm new to midi programming, there's 2 init functions the global init and launchpad init that access ext to initialize things that are part of launchpad, it seems to be the same thing.

thanks