### PR TITLE
Added work-around for record arming being disabled when arranger's armed

### DIFF
--- a/src/LaunchPad.ts
+++ b/src/LaunchPad.ts
@@ -169,6 +169,9 @@ class LaunchPad {
           ext.trackBank.getItemAt(trackIdx).clipLauncherSlotBank().setIndication(v);
         }
       });
+
+      ext.prefs.ensureRecordArming = prefs.getBooleanSetting("Ensure track arming works in arranger mode", "Record Arming Workaround", false);
+      ext.prefs.ensureOnlyOneIsArmed = prefs.getBooleanSetting("Ensure non-selected tracks are disarmed in arranger mode", "Record Arming Workaround", false);
     }
 
     // Setup some more random toggles.
@@ -195,6 +198,9 @@ class LaunchPad {
 
       // We want to access these in the Layers.
       ext.cursorClip.getLoopLength().markInterested();
+      
+      ext.trackBank.channelCount().markInterested();
+      ext.transport.isArrangerRecordEnabled().markInterested();
     }
 
     // Grid orientation.

--- a/src/Layers/Session.ts
+++ b/src/Layers/Session.ts
@@ -232,7 +232,21 @@ class SessionLayer extends Layer {
     if (Layer.isButtonHeld(Button.Shift)) {
       return;
     }
+    
     ext.trackBank.getItemAt(idx).selectInMixer();
+    
+    if (!ext.transport.isArrangerRecordEnabled().get()) {
+      // Recording is disabled, we don't need the workaround below
+      return;
+    }
+
+    for (let i = 0; i < ext.trackBank.channelCount().get(); i++) {
+      if ((i === idx) && ext.prefs.ensureRecordArming) {
+        ext.trackBank.getItemAt(idx).arm().set(true)
+      } else if (ext.prefs.ensureOnlyOneIsArmed) {
+        ext.trackBank.getItemAt(i).arm().set(false)
+      }
+    }
   }
 
   onScenePush(idx: number) {


### PR DESCRIPTION
Thanks to our discussion, I think I've found a solution that works!

Haven't tried it more extensively (e.g. with many more devices) yet, since I'm doing this at my break, but it seemed to be working for me!